### PR TITLE
試合数の計上タイミングと集計表示を改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,12 +142,12 @@
                             </tr>
                             <tr>
                                 <th class="label">コイン</th>
-                                <td class="value" id="coinSuccess">0</td>
+                                <td class="value" id="coinSuccess">0 / 0</td>
                                 <td class="rate" id="successRate">0%</td>
                             </tr>
                             <tr>
                                 <th class="label">勝利数</th>
-                                <td class="value" id="winCount">0</td>
+                                <td class="value" id="winCount">0 / 0</td>
                                 <td class="rate" id="winRate">0%</td>
                             </tr>
                         </table>
@@ -215,12 +215,12 @@
                             </tr>
                             <tr>
                                 <th class="label" id="coinLabel">先攻</th>
-                                <td class="value" id="coinSuccess">0</td>
+                                <td class="value" id="coinSuccess">0 / 0</td>
                                 <td class="rate" id="successRate">0%</td>
                             </tr>
                             <tr>
                                 <th class="label">勝利数</th>
-                                <td class="value" id="winCount">0</td>
+                                <td class="value" id="winCount">0 / 0</td>
                                 <td class="rate" id="winRate">0%</td>
                             </tr>
                         </table>
@@ -283,12 +283,12 @@
                                 </tr>
                                 <tr>
                                     <th class="label">コイン</th>
-                                    <td class="value" id="coinSuccess">0</td>
+                                    <td class="value" id="coinSuccess">0 / 0</td>
                                     <td class="rate" id="successRate">0%</td>
                                 </tr>
                                 <tr>
                                     <th class="label">勝利数</th>
-                                    <td class="value" id="winCount">0</td>
+                                    <td class="value" id="winCount">0 / 0</td>
                                     <td class="rate" id="winRate">0%</td>
                                 </tr>
                             </table>
@@ -348,12 +348,12 @@
                                 </tr>
                                 <tr>
                                     <th class="label" id="coinLabel">先攻</th>
-                                    <td class="value" id="coinSuccess">0</td>
+                                    <td class="value" id="coinSuccess">0 / 0</td>
                                     <td class="rate" id="successRate">0%</td>
                                 </tr>
                                 <tr>
                                     <th class="label">勝利数</th>
-                                    <td class="value" id="winCount">0</td>
+                                    <td class="value" id="winCount">0 / 0</td>
                                     <td class="rate" id="winRate">0%</td>
                                 </tr>
                             </table>

--- a/scripts/shadowverse-widget.js
+++ b/scripts/shadowverse-widget.js
@@ -17,7 +17,7 @@ class ShadowverseWidget extends BaseWidget {
         // 先攻/後攻の表示を切り替え
         if (this.isFirstMode) {
             document.getElementById('coinLabel').textContent = '先攻';
-            document.getElementById('coinSuccess').textContent = this.firstCount;
+            document.getElementById('coinSuccess').textContent = `${this.firstCount} / ${totalTurns}`;
             document.getElementById('successRate').textContent = (totalTurns > 0 ? Math.round((this.firstCount / totalTurns) * 100) : 0) + '%';
             // インジケーターは常に「先攻数：」「後攻数：」の順番で固定
             document.getElementById('detailLabel1').textContent = '先攻数：';
@@ -26,7 +26,7 @@ class ShadowverseWidget extends BaseWidget {
             document.getElementById('detailCoinFail').textContent = this.secondCount;
         } else {
             document.getElementById('coinLabel').textContent = '後攻';
-            document.getElementById('coinSuccess').textContent = this.secondCount;
+            document.getElementById('coinSuccess').textContent = `${this.secondCount} / ${totalTurns}`;
             document.getElementById('successRate').textContent = (totalTurns > 0 ? Math.round((this.secondCount / totalTurns) * 100) : 0) + '%';
             // インジケーターは常に「先攻数：」「後攻数：」の順番で固定
             document.getElementById('detailLabel1').textContent = '先攻数：';
@@ -40,12 +40,14 @@ class ShadowverseWidget extends BaseWidget {
     addCoinSuccess() { 
         // 「先攻」ボタンが押された時は常に先攻にカウントアップ
         this.firstCount++;
+        this.recordMatchStart();
         this.updateDisplay(); 
     }
 
     addCoinFail() { 
         // 「後攻」ボタンが押された時は常に後攻にカウントアップ
         this.secondCount++;
+        this.recordMatchStart();
         this.updateDisplay(); 
     }
 
@@ -85,4 +87,4 @@ function initializeShadowverseWidget() {
 }
 
 // DOM読み込み完了時に初期化
-document.addEventListener('DOMContentLoaded', initializeShadowverseWidget); 
+document.addEventListener('DOMContentLoaded', initializeShadowverseWidget);

--- a/scripts/widget.js
+++ b/scripts/widget.js
@@ -1,6 +1,7 @@
 // 基底ウィジェットクラス - 共通機能を提供
 class BaseWidget {
     constructor() {
+        this.matches = 0;
         this.wins = 0;
         this.losses = 0;
         this.gameType = 'base';
@@ -8,13 +9,18 @@ class BaseWidget {
 
     // 共通の表示更新関数
     updateDisplay() {
-        const totalMatches = this.wins + this.losses;
+        const completedMatches = this.wins + this.losses;
         
-        document.getElementById('matchCount').textContent = totalMatches;
-        document.getElementById('winCount').textContent = this.wins;
-        document.getElementById('winRate').textContent = (totalMatches > 0 ? Math.round((this.wins / totalMatches) * 100) : 0) + '%';
+        document.getElementById('matchCount').textContent = this.matches;
+        document.getElementById('winCount').textContent = `${this.wins} / ${this.matches}`;
+        document.getElementById('winRate').textContent = (completedMatches > 0 ? Math.round((this.wins / completedMatches) * 100) : 0) + '%';
         document.getElementById('detailWin').textContent = this.wins;
         document.getElementById('detailLose').textContent = this.losses;
+    }
+
+    // コイン結果（先攻/後攻を含む）の入力時に試合開始を記録
+    recordMatchStart() {
+        this.matches++;
     }
 
     // 共通の勝利/敗北関数
@@ -30,6 +36,7 @@ class BaseWidget {
 
     // 共通のリセット関数
     resetAll() { 
+        this.matches = 0;
         this.wins = 0; 
         this.losses = 0; 
         this.updateDisplay(); 
@@ -88,4 +95,4 @@ function initializeWidget() {
     if (currentWidget) {
         currentWidget.initialize();
     }
-} 
+}

--- a/scripts/yugioh-widget.js
+++ b/scripts/yugioh-widget.js
@@ -13,7 +13,7 @@ class YugiohWidget extends BaseWidget {
         
         const totalCoins = this.coinSuccesses + this.coinFails;
         
-        document.getElementById('coinSuccess').textContent = this.coinSuccesses;
+        document.getElementById('coinSuccess').textContent = `${this.coinSuccesses} / ${totalCoins}`;
         document.getElementById('successRate').textContent = (totalCoins > 0 ? Math.round((this.coinSuccesses / totalCoins) * 100) : 0) + '%';
         
         // 詳細エリアも更新
@@ -23,12 +23,14 @@ class YugiohWidget extends BaseWidget {
 
     // マスターデュエル用のコイン関数
     addCoinSuccess() { 
-        this.coinSuccesses++; 
+        this.coinSuccesses++;
+        this.recordMatchStart();
         this.updateDisplay(); 
     }
 
     addCoinFail() { 
-        this.coinFails++; 
+        this.coinFails++;
+        this.recordMatchStart();
         this.updateDisplay(); 
     }
 
@@ -58,4 +60,4 @@ class YugiohWidget extends BaseWidget {
 function initializeYugiohWidget() {
     currentWidget = new YugiohWidget();
     currentWidget.initialize();
-} 
+}

--- a/templates/duel-widget.html
+++ b/templates/duel-widget.html
@@ -31,12 +31,12 @@
             </tr>
             <tr>
                 <th class="label">コイン</th>
-                <td class="value" id="coinSuccess">0</td>
+                <td class="value" id="coinSuccess">0 / 0</td>
                 <td class="rate" id="successRate">0%</td>
             </tr>
             <tr>
                 <th class="label">勝利数</th>
-                <td class="value" id="winCount">0</td>
+                <td class="value" id="winCount">0 / 0</td>
                 <td class="rate" id="winRate">0%</td>
             </tr>
         </table>
@@ -59,4 +59,4 @@
         <button class="btn" onclick="addWin()">勝利</button>
         <button class="btn" onclick="addLose()">敗北</button>
     </div>
-</div> 
+</div>

--- a/templates/shadowverse-widget.html
+++ b/templates/shadowverse-widget.html
@@ -31,12 +31,12 @@
             </tr>
             <tr>
                 <th class="label" id="coinLabel">先攻</th>
-                <td class="value" id="coinSuccess">0</td>
+                <td class="value" id="coinSuccess">0 / 0</td>
                 <td class="rate" id="successRate">0%</td>
             </tr>
             <tr>
                 <th class="label">勝利数</th>
-                <td class="value" id="winCount">0</td>
+                <td class="value" id="winCount">0 / 0</td>
                 <td class="rate" id="winRate">0%</td>
             </tr>
         </table>


### PR DESCRIPTION
## 概要

- 試合数を勝敗入力時ではなく、コイン結果（シャドバWBでは先攻・後攻）の入力時に加算
- コイン・先攻・後攻のメイン表示を `現在数 / 入力総数` 形式へ変更
- 勝利数のメイン表示を `勝利数 / 試合数` 形式へ変更
- 初期表示とリセット後の表示を `0 / 0` に統一

## 背景

従来は試合数を `勝利数 + 敗北数` から算出していたため、対戦を開始しても勝敗を入力するまで試合数へ反映されませんでした。また、コイン結果と勝利数の表示は単独の数値だったため、全体に対する内訳を把握するには割合表示や詳細欄を見る必要がありました。

## 影響

コイン結果または先攻・後攻を入力した時点で試合数が増え、配信中でも現在値と総数をひと目で確認できます。勝率は従来どおり、勝敗入力済みの試合だけを分母として計算します。

## 確認内容

- `node --check` による3つのウィジェットスクリプトの構文確認
- 遊戯王MDのコイン成功・失敗、勝敗、リセットのカウント検証
- シャドバWBの先攻・後攻、表示モード切り替え、勝敗、リセットのカウント検証
- ステージ済み差分の空白エラー検査
- 起動したアプリで変更後の表示を手動確認