### PR TITLE
v0.3リリースに向けてバージョンを同期

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dcg-duel-widget",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dcg-duel-widget",
-      "version": "1.0.0",
+      "version": "0.3.0",
       "devDependencies": {
         "@electron/packager": "^20.0.4",
         "electron": "^43.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcg-duel-widget",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "description": "遊戯王マスターデュエル配信用ウィジェット",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## 概要

- `package.json`のアプリバージョンを`1.0.0`から`0.3.0`へ更新
- `package-lock.json`のルートパッケージバージョンも`0.3.0`へ同期

## 背景

既存のGitHub Releaseは`v0.2`まで進んでいる一方、npmパッケージメタデータは`1.0.0`のままで、リリースタグとアプリバージョンが一致していませんでした。`v0.3`のタグ作成とWindowsバイナリ生成に先立ち、アプリ側のバージョンを`0.3.0`へそろえます。

## 影響

- 次回ビルドのアプリバージョンが`0.3.0`になります
- 実行時ロジック、UI、依存パッケージには変更ありません

## 確認内容

- `package.json`と`package-lock.json`内の3箇所がすべて`0.3.0`で一致
- `npm ls --depth=0`が正常終了
- `npm audit --json`: 脆弱性0件
- ステージ済み差分の空白エラー検査に成功